### PR TITLE
Switch aether imports to maven-resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.version>3.0</maven.version>
+    <javaVersion>7</javaVersion>
+    <maven.version>3.5.2</maven.version>
   </properties>
 
   <dependencies>
@@ -87,27 +88,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>1.7</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>1.7</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-      <version>0.9.0.M2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>0.9.0.M2</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/main/java/org/apache/maven/shared/artifact/filter/collection/ArtifactTransitivityFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/collection/ArtifactTransitivityFilter.java
@@ -118,15 +118,15 @@ public class ArtifactTransitivityFilter
             {
                 try
                 {
-                    @SuppressWarnings( "unchecked" ) List<org.sonatype.aether.graph.Dependency> dependencies =
-                        (List<org.sonatype.aether.graph.Dependency>) Invoker.invoke( resolutionResult,
+                    @SuppressWarnings( "unchecked" ) List<org.eclipse.aether.graph.Dependency> dependencies =
+                        (List<org.eclipse.aether.graph.Dependency>) Invoker.invoke( resolutionResult,
                                                                                      "getDependencies" );
 
-                    for ( org.sonatype.aether.graph.Dependency dependency : dependencies )
+                    for ( org.eclipse.aether.graph.Dependency dependency : dependencies )
                     {
                         Artifact mavenArtifact = 
                                         (Artifact) Invoker.invoke( RepositoryUtils.class, "toArtifact",
-                                                                    org.sonatype.aether.artifact.Artifact.class,
+                                                                    org.eclipse.aether.artifact.Artifact.class,
                                                                     dependency.getArtifact() );
 
                         transitiveArtifacts.add( mavenArtifact.getDependencyConflictId() );

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/AndFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/AndFilter.java
@@ -28,7 +28,7 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.AndDependencyFilter
+ * @see org.eclipse.aether.util.filter.AndDependencyFilter
  * @see org.eclipse.aether.util.filter.AndDependencyFilter
  */
 public class AndFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/ExclusionsFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/ExclusionsFilter.java
@@ -28,7 +28,7 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.ExclusionsDependencyFilter
+ * @see org.eclipse.aether.util.filter.ExclusionsDependencyFilter
  * @see org.eclipse.aether.util.filter.ExclusionsDependencyFilter
  */
 public class ExclusionsFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/OrFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/OrFilter.java
@@ -28,7 +28,7 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.OrDependencyFilter
+ * @see org.eclipse.aether.util.filter.OrDependencyFilter
  * @see org.eclipse.aether.util.filter.OrDependencyFilter
  */
 public class OrFilter implements TransformableFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/PatternExclusionsFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/PatternExclusionsFilter.java
@@ -40,9 +40,9 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter
  * @see org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter
- * @see org.sonatype.aether.version.VersionScheme
+ * @see org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter
+ * @see org.eclipse.aether.version.VersionScheme
  * @see org.eclipse.aether.version.VersionScheme
  */
 public class PatternExclusionsFilter implements TransformableFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/PatternInclusionsFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/PatternInclusionsFilter.java
@@ -41,9 +41,9 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.PatternInclusionsDependencyFilter
  * @see org.eclipse.aether.util.filter.PatternInclusionsDependencyFilter
- * @see org.sonatype.aether.version.VersionScheme
+ * @see org.eclipse.aether.util.filter.PatternInclusionsDependencyFilter
+ * @see org.eclipse.aether.version.VersionScheme
  * @see org.eclipse.aether.version.VersionScheme
  */
 public class PatternInclusionsFilter implements TransformableFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/ScopeFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/ScopeFilter.java
@@ -29,7 +29,7 @@ import java.util.Collections;
  * @author Robert Scholte
  * @since 3.0
  * 
- * @see org.sonatype.aether.util.filter.ScopeDependencyFilter
+ * @see org.eclipse.aether.util.filter.ScopeDependencyFilter
  * @see org.eclipse.aether.util.filter.ScopeDependencyFilter
  */
 public class ScopeFilter implements TransformableFilter

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherFilterTransformer.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherFilterTransformer.java
@@ -34,14 +34,14 @@ import org.apache.maven.shared.artifact.filter.resolve.PatternExclusionsFilter;
 import org.apache.maven.shared.artifact.filter.resolve.PatternInclusionsFilter;
 import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
 import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
-import org.sonatype.aether.graph.DependencyFilter;
-import org.sonatype.aether.graph.DependencyNode;
-import org.sonatype.aether.util.filter.AndDependencyFilter;
-import org.sonatype.aether.util.filter.ExclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.OrDependencyFilter;
-import org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.PatternInclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.ScopeDependencyFilter;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.filter.AndDependencyFilter;
+import org.eclipse.aether.util.filter.ExclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.OrDependencyFilter;
+import org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.PatternInclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 
 /**
  * FilterTransformer implementation for Sonatypes Aether

--- a/src/main/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherNode.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherNode.java
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.shared.artifact.filter.resolve.Node;
-import org.sonatype.aether.graph.Dependency;
-import org.sonatype.aether.graph.DependencyNode;
-import org.sonatype.aether.graph.Exclusion;
-import org.sonatype.aether.util.artifact.ArtifactProperties;
+import org.eclipse.aether.artifact.ArtifactProperties;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.Exclusion;
 
 /**
  * Adapter of a Sonatype Aether DependencyNode for common Node

--- a/src/test/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherFilterTransformerTest.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherFilterTransformerTest.java
@@ -36,17 +36,17 @@ import org.apache.maven.shared.artifact.filter.resolve.PatternExclusionsFilter;
 import org.apache.maven.shared.artifact.filter.resolve.PatternInclusionsFilter;
 import org.apache.maven.shared.artifact.filter.resolve.ScopeFilter;
 import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
-import org.sonatype.aether.graph.DependencyFilter;
-import org.sonatype.aether.graph.Dependency;
-import org.sonatype.aether.graph.DependencyNode;
-import org.sonatype.aether.util.artifact.DefaultArtifact;
-import org.sonatype.aether.util.filter.AndDependencyFilter;
-import org.sonatype.aether.util.filter.ExclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.OrDependencyFilter;
-import org.sonatype.aether.util.filter.PatternExclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.PatternInclusionsDependencyFilter;
-import org.sonatype.aether.util.filter.ScopeDependencyFilter;
-import org.sonatype.aether.util.graph.DefaultDependencyNode;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.filter.AndDependencyFilter;
+import org.eclipse.aether.util.filter.ExclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.OrDependencyFilter;
+import org.eclipse.aether.util.filter.PatternExclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.PatternInclusionsDependencyFilter;
+import org.eclipse.aether.util.filter.ScopeDependencyFilter;
 import org.junit.Test;
 
 public class SonatypeAetherFilterTransformerTest

--- a/src/test/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherNodeTest.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/resolve/transform/SonatypeAetherNodeTest.java
@@ -26,12 +26,12 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.apache.maven.shared.artifact.filter.resolve.Node;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.junit.Test;
-import org.sonatype.aether.graph.Dependency;
-import org.sonatype.aether.graph.DependencyNode;
-import org.sonatype.aether.graph.Exclusion;
-import org.sonatype.aether.util.artifact.DefaultArtifact;
-import org.sonatype.aether.util.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.graph.Exclusion;
 
 public class SonatypeAetherNodeTest
 {


### PR DESCRIPTION
Stop using the old `aether` and `eclipse-aether` libraries, who's code is now part of `maven-resolver`, under the `org.eclipse` package. The old libraries are very abandoned, to the point that their websites have gone missing. They depend on some scarily broken libraries, which is a problem for distros like Debian.

Tests green. Only non-find-and-replace changes is to add some properties:
 * `<javaVersion>7` as `maven-resolver` uses 7 and otherwise enforcer gets angry, and
 * `<maven.version>3.5.2`, as pre-3.5 maven used aether for other reasons, so it still ends up polluting the tree.

JIRA issue: https://issues.apache.org/jira/browse/MSHARED-683