### PR TITLE
Big speed improvements for patterns that do not contain any wildcard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,5 +160,17 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.26</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternExcludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternExcludesArtifactFilter.java
@@ -56,7 +56,7 @@ public class PatternExcludesArtifactFilter
 
         if ( !shouldInclude )
         {
-            addFilteredArtifactId( artifact.getId() );
+            addFilteredArtifactId( artifact );
         }
 
         return shouldInclude;

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternExcludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternExcludesArtifactFilter.java
@@ -56,7 +56,7 @@ public class PatternExcludesArtifactFilter
 
         if ( !shouldInclude )
         {
-            addFilteredArtifactId( artifact );
+            addFilteredArtifact( artifact );
         }
 
         return shouldInclude;

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -170,7 +170,7 @@ public class PatternIncludesArtifactFilter
                 {
                     char[][] depGatvCharArray = tokenizeAndSplit( trailItem );
                     match = match( depGatvCharArray );
-                    if ( match != null)
+                    if ( match != null )
                     {
                         return match;
                     }
@@ -213,7 +213,7 @@ public class PatternIncludesArtifactFilter
             if ( pattern.matches( gatvCharArray ) )
             {
                 patternsTriggered.add( pattern );
-                return !(pattern instanceof NegativePattern);
+                return !( pattern instanceof NegativePattern );
             }
         }
 
@@ -342,6 +342,7 @@ public class PatternIncludesArtifactFilter
         return tokens;
     }
 
+    @SuppressWarnings( "InnerAssignment" )
     static boolean match( char[] patArr, char[] strArr, boolean isVersion )
     {
         int patIdxStart = 0;
@@ -744,11 +745,11 @@ public class PatternIncludesArtifactFilter
     /**
      * Abstract class for patterns
      */
-    static abstract class Pattern
+    abstract static class Pattern
     {
         private final String pattern;
 
-        public Pattern( String pattern )
+        Pattern( String pattern )
         {
             this.pattern = Objects.requireNonNull( pattern );
         }
@@ -773,7 +774,8 @@ public class PatternIncludesArtifactFilter
         }
 
         @Override
-        public String toString() {
+        public String toString()
+        {
             return pattern;
         }
     }
@@ -785,7 +787,7 @@ public class PatternIncludesArtifactFilter
     {
         private final Pattern[] patterns;
 
-        public AndPattern( String pattern, Pattern[] patterns )
+        AndPattern( String pattern, Pattern[] patterns )
         {
             super( pattern );
             this.patterns = patterns;
@@ -836,7 +838,7 @@ public class PatternIncludesArtifactFilter
     {
         private final Pattern[] patterns;
 
-        public OrPattern( String pattern, Pattern[] patterns )
+        OrPattern( String pattern, Pattern[] patterns )
         {
             super( pattern );
             this.patterns = patterns;
@@ -867,7 +869,7 @@ public class PatternIncludesArtifactFilter
         private final int posMin;
         private final int posMax;
 
-        public PosPattern( String pattern, char[] patternCharArray, int posMin, int posMax )
+        PosPattern( String pattern, char[] patternCharArray, int posMin, int posMax )
         {
             super( pattern );
             this.patternCharArray = patternCharArray;
@@ -899,7 +901,7 @@ public class PatternIncludesArtifactFilter
         private final int posMin;
         private final int posMax;
 
-        public EqPattern( String pattern, char[] patternCharArray, int posMin, int posMax )
+        EqPattern( String pattern, char[] patternCharArray, int posMin, int posMax )
         {
             super( pattern );
             this.token = patternCharArray;
@@ -912,7 +914,7 @@ public class PatternIncludesArtifactFilter
         {
             for ( int i = posMin; i <= posMax; i++ )
             {
-                if (Arrays.equals( token, parts[i] ) )
+                if ( Arrays.equals( token, parts[i] ) )
                 {
                     return true;
                 }
@@ -940,7 +942,7 @@ public class PatternIncludesArtifactFilter
      */
     static class MatchAllPattern extends Pattern
     {
-        public MatchAllPattern( String pattern )
+        MatchAllPattern( String pattern )
         {
             super( pattern );
         }

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -397,11 +397,14 @@ public class PatternIncludesArtifactFilter
     public void reportMissedCriteria( final Logger logger )
     {
         // if there are no patterns, there is nothing to report.
-        if ( !positivePatterns.isEmpty() || !negativePatterns.isEmpty() )
+        if ( !positivePatterns.isEmpty() || !negativePatterns.isEmpty()
+                || !simplePositivePatterns.isEmpty() || !simpleNegativePatterns.isEmpty() )
         {
             final List<String> missed = new ArrayList<>();
             missed.addAll( positivePatterns );
+            missed.addAll( simplePositivePatterns );
             missed.addAll( negativePatterns );
+            missed.addAll( simpleNegativePatterns );
 
             missed.removeAll( patternsTriggered );
 
@@ -437,6 +440,10 @@ public class PatternIncludesArtifactFilter
     protected String getPatternsAsString()
     {
         final StringBuilder buffer = new StringBuilder();
+        for ( String pattern : simplePositivePatterns )
+        {
+            buffer.append( "\no '" ).append( pattern ).append( "'" );
+        }
         for ( String pattern : positivePatterns )
         {
             buffer.append( "\no '" ).append( pattern ).append( "'" );

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -53,7 +53,7 @@ public class PatternIncludesArtifactFilter
     /** Holds simple patterns: those that can use direct matching */
     private final Map<Integer, Map<String, Pattern>> simplePatterns;
 
-    /** Wether the dependency trail should be checked */
+    /** Whether the dependency trail should be checked */
     private final boolean actTransitively;
 
     /** Set of patterns that have been triggered */

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -135,7 +135,7 @@ public class PatternIncludesArtifactFilter
 
         if ( !shouldInclude )
         {
-            addFilteredArtifactId( artifact );
+            addFilteredArtifact( artifact );
         }
 
         return shouldInclude;
@@ -223,7 +223,7 @@ public class PatternIncludesArtifactFilter
     /**
      * @param artifact add artifact to the filtered artifacts list.
      */
-    protected void addFilteredArtifactId( final Artifact artifact )
+    protected void addFilteredArtifact( final Artifact artifact )
     {
         filteredArtifact.add( artifact );
     }

--- a/src/test/java/org/apache/maven/shared/artifact/filter/AbstractPatternArtifactFilterTest.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/AbstractPatternArtifactFilterTest.java
@@ -52,16 +52,16 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId2 = "artifact2";
 
         Artifact artifact1 = mock( Artifact.class );
-        when( artifact1.getDependencyConflictId() ).thenReturn( groupId1 + ":" + artifactId1 + ":jar" );
         when( artifact1.getGroupId() ).thenReturn( groupId1 );
         when( artifact1.getArtifactId() ).thenReturn( artifactId1 );
-        when( artifact1.getId() ).thenReturn( groupId1 + ":" + artifactId1 + ":jar:version" );
+        when( artifact1.getType() ).thenReturn( "jar" );
+        when( artifact1.getBaseVersion() ).thenReturn( "version" );
         
         Artifact artifact2 = mock( Artifact.class );
-        when( artifact2.getDependencyConflictId() ).thenReturn( groupId2 + ":" + artifactId2 + ":jar" );
         when( artifact2.getGroupId() ).thenReturn( groupId2 );
         when( artifact2.getArtifactId() ).thenReturn( artifactId2 );
-        when( artifact2.getId() ).thenReturn( groupId2 + ":" + artifactId2 + ":jar:version" );
+        when( artifact2.getType() ).thenReturn( "jar" );
+        when( artifact2.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( groupId1 + ":" + artifactId1 + ":*" );
@@ -91,16 +91,16 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId2 = "artifact2";
 
         Artifact artifact1 = mock( Artifact.class );
-        when( artifact1.getDependencyConflictId() ).thenReturn( groupId1 + ":" + artifactId1 + ":jar" );
         when( artifact1.getGroupId() ).thenReturn( groupId1 );
         when( artifact1.getArtifactId() ).thenReturn( artifactId1 );
-        when( artifact1.getId() ).thenReturn( groupId1 + ":" + artifactId1 + ":jar:version" );
+        when( artifact1.getType() ).thenReturn( "jar" );
+        when( artifact1.getBaseVersion() ).thenReturn( "version" );
 
         Artifact artifact2 = mock( Artifact.class );
-        when( artifact2.getDependencyConflictId() ).thenReturn( groupId2 + ":" + artifactId2 + ":jar" );
         when( artifact2.getGroupId() ).thenReturn( groupId2 );
         when( artifact2.getArtifactId() ).thenReturn( artifactId2 );
-        when( artifact2.getId() ).thenReturn( groupId2 + ":" + artifactId2 + ":jar:version" );
+        when( artifact2.getType() ).thenReturn( "jar" );
+        when( artifact2.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( groupId1 + "*" );
@@ -127,10 +127,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final ArtifactFilter filter = createFilter( Collections.singletonList( groupId + ":" + artifactId ) );
 
@@ -151,10 +151,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final ArtifactFilter filter = createFilter( Collections.singletonList( groupId + ":" + artifactId + ":jar" ) );
 
@@ -175,10 +175,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "otherGroup:" + artifactId + ":jar" );
@@ -203,10 +203,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( groupId + "otherArtifact:jar" );
@@ -231,10 +231,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "otherGroup:otherArtifact:jar" );
@@ -265,10 +265,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final List<String> patterns = Collections.singletonList( depTrailItem );
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
         when( artifact.getDependencyTrail() ).thenReturn( depTrail );
 
         final ArtifactFilter filter = createFilter( patterns, true );
@@ -296,10 +296,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final List<String> patterns = Collections.singletonList( "otherGroup*" );
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
         when( artifact.getDependencyTrail() ).thenReturn( depTrail );
 
         final ArtifactFilter filter = createFilter( patterns, true );
@@ -321,10 +321,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "!group:artifact:jar" );
@@ -348,10 +348,10 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "artifact";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "group:*:jar" );
@@ -376,10 +376,10 @@ public abstract class AbstractPatternArtifactFilterTest
 
         Artifact artifact = mock( Artifact.class );
 
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "*:artifact:*" );
@@ -404,10 +404,10 @@ public abstract class AbstractPatternArtifactFilterTest
 
         Artifact artifact = mock( Artifact.class );
 
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "group:some-*-id" );
@@ -432,10 +432,10 @@ public abstract class AbstractPatternArtifactFilterTest
 
         Artifact artifact = mock( Artifact.class );
 
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "some.group*" );
@@ -465,16 +465,16 @@ public abstract class AbstractPatternArtifactFilterTest
         final List<String> patterns = Collections.singletonList( "*:jar:*" );
 
         Artifact artifact1 = mock( Artifact.class );
-        when( artifact1.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact1.getGroupId() ).thenReturn( groupId );
         when( artifact1.getArtifactId() ).thenReturn( artifactId );
-        when( artifact1.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
-        
+        when( artifact1.getType() ).thenReturn( "jar" );
+        when( artifact1.getBaseVersion() ).thenReturn( "version" );
+
         Artifact artifact2 = mock( Artifact.class );
-        when( artifact2.getDependencyConflictId() ).thenReturn( otherGroup + ":" + otherArtifact + ":" + otherType );
         when( artifact2.getGroupId() ).thenReturn( otherGroup );
         when( artifact2.getArtifactId() ).thenReturn( otherArtifact );
-        when( artifact2.getId() ).thenReturn( otherGroup + ":" + otherArtifact + ":" + otherType + ":version" );
+        when( artifact2.getType() ).thenReturn( otherType );
+        when( artifact2.getBaseVersion() ).thenReturn( "version" );
         when( artifact2.getDependencyTrail() ).thenReturn( Collections.<String> emptyList() );
 
         final ArtifactFilter filter = createFilter( patterns, true );
@@ -498,13 +498,40 @@ public abstract class AbstractPatternArtifactFilterTest
         final String artifactId = "some-artifact-id";
 
         Artifact artifact = mock( Artifact.class );
-        when( artifact.getDependencyConflictId() ).thenReturn( groupId + ":" + artifactId + ":jar" );
         when( artifact.getGroupId() ).thenReturn( groupId );
         when( artifact.getArtifactId() ).thenReturn( artifactId );
-        when( artifact.getId() ).thenReturn( groupId + ":" + artifactId + ":jar:version" );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "version" );
 
         final List<String> patterns = new ArrayList<>();
         patterns.add( "com.mycompany.*:*:jar:*:*" );
+
+        final ArtifactFilter filter = createFilter( patterns );
+
+        if ( isInclusionNotExpected() )
+        {
+            assertFalse( filter.include( artifact ) );
+        }
+        else
+        {
+            assertTrue( filter.include( artifact ) );
+        }
+    }
+
+    @Test
+    public void testWithVersionRange()
+    {
+        final String groupId = "com.mycompany.myproject";
+        final String artifactId = "some-artifact-id";
+
+        Artifact artifact = mock( Artifact.class );
+        when( artifact.getGroupId() ).thenReturn( groupId );
+        when( artifact.getArtifactId() ).thenReturn( artifactId );
+        when( artifact.getType() ).thenReturn( "jar" );
+        when( artifact.getBaseVersion() ).thenReturn( "1.1" );
+
+        final List<String> patterns = new ArrayList<>();
+        patterns.add( "com.mycompany.myproject:some-artifact-id:jar:*:[1.0,2.0)" );
 
         final ArtifactFilter filter = createFilter( patterns );
 

--- a/src/test/java/org/apache/maven/shared/artifact/filter/OldPatternIncludesArtifactFilter.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/OldPatternIncludesArtifactFilter.java
@@ -1,0 +1,428 @@
+package org.apache.maven.shared.artifact.filter;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.codehaus.plexus.logging.Logger;
+
+/**
+ * TODO: include in maven-artifact in future
+ *
+ * @author <a href="mailto:brett@apache.org">Brett Porter</a>
+ * @see StrictPatternIncludesArtifactFilter
+ */
+public class OldPatternIncludesArtifactFilter
+        implements ArtifactFilter, StatisticsReportingArtifactFilter
+{
+    private final List<String> positivePatterns;
+
+    private final List<String> negativePatterns;
+
+    private final boolean actTransitively;
+
+    private final Set<String> patternsTriggered = new HashSet<>();
+
+    private final List<String> filteredArtifactIds = new ArrayList<>();
+
+    /**
+     * @param patterns The pattern to be used.
+     */
+    public OldPatternIncludesArtifactFilter( final Collection<String> patterns )
+    {
+        this( patterns, false );
+    }
+
+    /**
+     * @param patterns The pattern to be used.
+     * @param actTransitively transitive yes/no.
+     */
+    public OldPatternIncludesArtifactFilter( final Collection<String> patterns, final boolean actTransitively )
+    {
+        this.actTransitively = actTransitively;
+        final List<String> pos = new ArrayList<>();
+        final List<String> neg = new ArrayList<>();
+        if ( patterns != null && !patterns.isEmpty() )
+        {
+            for ( String pattern : patterns )
+            {
+                if ( pattern.startsWith( "!" ) )
+                {
+                    neg.add( pattern.substring( 1 ) );
+                }
+                else
+                {
+                    pos.add( pattern );
+                }
+            }
+        }
+
+        positivePatterns = pos;
+        negativePatterns = neg;
+    }
+
+    /** {@inheritDoc} */
+    public boolean include( final Artifact artifact )
+    {
+        final boolean shouldInclude = patternMatches( artifact );
+
+        if ( !shouldInclude )
+        {
+            addFilteredArtifactId( artifact.getId() );
+        }
+
+        return shouldInclude;
+    }
+
+    /**
+     * @param artifact to check for.
+     * @return true if the match is true false otherwise.
+     */
+    protected boolean patternMatches( final Artifact artifact )
+    {
+        return positiveMatch( artifact ) == Boolean.TRUE || negativeMatch( artifact ) == Boolean.FALSE;
+    }
+
+    /**
+     * @param artifactId add artifact to the filtered artifacts list.
+     */
+    protected void addFilteredArtifactId( final String artifactId )
+    {
+        filteredArtifactIds.add( artifactId );
+    }
+
+    private Boolean negativeMatch( final Artifact artifact )
+    {
+        if ( negativePatterns == null || negativePatterns.isEmpty() )
+        {
+            return null;
+        }
+        else
+        {
+            return match( artifact, negativePatterns );
+        }
+    }
+
+    /**
+     * @param artifact check for positive match.
+     * @return true/false.
+     */
+    protected Boolean positiveMatch( final Artifact artifact )
+    {
+        if ( positivePatterns == null || positivePatterns.isEmpty() )
+        {
+            return null;
+        }
+        else
+        {
+            return match( artifact, positivePatterns );
+        }
+    }
+
+    private boolean match( final Artifact artifact, final List<String> patterns )
+    {
+        final String shortId = ArtifactUtils.versionlessKey( artifact );
+        final String id = artifact.getDependencyConflictId();
+        final String wholeId = artifact.getId();
+
+        if ( matchAgainst( wholeId, patterns, false ) )
+        {
+            return true;
+        }
+
+        if ( matchAgainst( id, patterns, false ) )
+        {
+            return true;
+        }
+
+        if ( matchAgainst( shortId, patterns, false ) )
+        {
+            return true;
+        }
+
+        if ( actTransitively )
+        {
+            final List<String> depTrail = artifact.getDependencyTrail();
+
+            if ( depTrail != null && depTrail.size() > 1 )
+            {
+                for ( String trailItem : depTrail )
+                {
+                    if ( matchAgainst( trailItem, patterns, true ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean matchAgainst( final String value, final List<String> patterns, final boolean regionMatch )
+    {
+        final String[] tokens = value.split( ":" );
+        for ( String pattern : patterns )
+        {
+            String[] patternTokens = pattern.split( ":" );
+
+            if ( patternTokens.length == 5 && tokens.length < 5 )
+            {
+                // 4th element is the classifier
+                if ( !"*".equals( patternTokens[3] ) )
+                {
+                    // classifier required, cannot be a match
+                    return false;
+                }
+                patternTokens = new String[] { patternTokens[0], patternTokens[1], patternTokens[2], patternTokens[4] };
+            }
+
+            // fail immediately if pattern tokens outnumber tokens to match
+            boolean matched = patternTokens.length <= tokens.length;
+
+            for ( int i = 0; matched && i < patternTokens.length; i++ )
+            {
+                matched = matches( tokens[i], patternTokens[i] );
+            }
+
+            // case of starting '*' like '*:jar:*'
+            // This really only matches from the end instead.....
+            if ( !matched && patternTokens.length < tokens.length && isFirstPatternWildcard( patternTokens ) )
+            {
+                matched = true;
+                int tokenOffset = tokens.length - patternTokens.length;
+                for ( int i = 0; matched && i < patternTokens.length; i++ )
+                {
+                    matched = matches( tokens[i + tokenOffset], patternTokens[i] );
+                }
+            }
+
+            if ( matched )
+            {
+                patternsTriggered.add( pattern );
+                return true;
+            }
+
+            if ( regionMatch && value.contains( pattern ) )
+            {
+                patternsTriggered.add( pattern );
+                return true;
+            }
+
+        }
+        return false;
+
+    }
+
+    private boolean isFirstPatternWildcard( String[] patternTokens )
+    {
+        return patternTokens.length > 0 && "*".equals( patternTokens[0] );
+    }
+
+    /**
+     * Gets whether the specified token matches the specified pattern segment.
+     *
+     * @param token the token to check
+     * @param pattern the pattern segment to match, as defined above
+     * @return <code>true</code> if the specified token is matched by the specified pattern segment
+     */
+    private boolean matches( final String token, final String pattern )
+    {
+        boolean matches;
+
+        // support full wildcard and implied wildcard
+        if ( "*".equals( pattern ) || pattern.length() == 0 )
+        {
+            matches = true;
+        }
+        // support contains wildcard
+        else if ( pattern.startsWith( "*" ) && pattern.endsWith( "*" ) )
+        {
+            final String contains = pattern.substring( 1, pattern.length() - 1 );
+
+            matches = token.contains( contains );
+        }
+        // support leading wildcard
+        else if ( pattern.startsWith( "*" ) )
+        {
+            final String suffix = pattern.substring( 1 );
+
+            matches = token.endsWith( suffix );
+        }
+        // support trailing wildcard
+        else if ( pattern.endsWith( "*" ) )
+        {
+            final String prefix = pattern.substring( 0, pattern.length() - 1 );
+
+            matches = token.startsWith( prefix );
+        }
+        // support wildcards in the middle of a pattern segment
+        else if ( pattern.indexOf( '*' ) > -1 )
+        {
+            String[] parts = pattern.split( "\\*" );
+            int lastPartEnd = -1;
+            boolean match = true;
+
+            for ( String part : parts )
+            {
+                int idx = token.indexOf( part );
+                if ( idx <= lastPartEnd )
+                {
+                    match = false;
+                    break;
+                }
+
+                lastPartEnd = idx + part.length();
+            }
+
+            matches = match;
+        }
+        // support versions range
+        else if ( pattern.startsWith( "[" ) || pattern.startsWith( "(" ) )
+        {
+            matches = isVersionIncludedInRange( token, pattern );
+        }
+        // support exact match
+        else
+        {
+            matches = token.equals( pattern );
+        }
+
+        return matches;
+    }
+
+    private boolean isVersionIncludedInRange( final String version, final String range )
+    {
+        try
+        {
+            return VersionRange.createFromVersionSpec( range ).containsVersion( new DefaultArtifactVersion( version ) );
+        }
+        catch ( final InvalidVersionSpecificationException e )
+        {
+            return false;
+        }
+    }
+
+    /** {@inheritDoc} */
+    public void reportMissedCriteria( final Logger logger )
+    {
+        // if there are no patterns, there is nothing to report.
+        if ( !positivePatterns.isEmpty() || !negativePatterns.isEmpty() )
+        {
+            final List<String> missed = new ArrayList<>();
+            missed.addAll( positivePatterns );
+            missed.addAll( negativePatterns );
+
+            missed.removeAll( patternsTriggered );
+
+            if ( !missed.isEmpty() && logger.isWarnEnabled() )
+            {
+                final StringBuilder buffer = new StringBuilder();
+
+                buffer.append( "The following patterns were never triggered in this " );
+                buffer.append( getFilterDescription() );
+                buffer.append( ':' );
+
+                for ( String pattern : missed )
+                {
+                    buffer.append( "\no  '" ).append( pattern ).append( "'" );
+                }
+
+                buffer.append( "\n" );
+
+                logger.warn( buffer.toString() );
+            }
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Includes filter:" + getPatternsAsString();
+    }
+
+    /**
+     * @return pattern as a string.
+     */
+    protected String getPatternsAsString()
+    {
+        final StringBuilder buffer = new StringBuilder();
+        for ( String pattern : positivePatterns )
+        {
+            buffer.append( "\no '" ).append( pattern ).append( "'" );
+        }
+
+        return buffer.toString();
+    }
+
+    /**
+     * @return description.
+     */
+    protected String getFilterDescription()
+    {
+        return "artifact inclusion filter";
+    }
+
+    /** {@inheritDoc} */
+    public void reportFilteredArtifacts( final Logger logger )
+    {
+        if ( !filteredArtifactIds.isEmpty() && logger.isDebugEnabled() )
+        {
+            final StringBuilder buffer =
+                    new StringBuilder( "The following artifacts were removed by this " + getFilterDescription() + ": " );
+
+            for ( String artifactId : filteredArtifactIds )
+            {
+                buffer.append( '\n' ).append( artifactId );
+            }
+
+            logger.debug( buffer.toString() );
+        }
+    }
+
+    /** {@inheritDoc} */
+    public boolean hasMissedCriteria()
+    {
+        // if there are no patterns, there is nothing to report.
+        if ( !positivePatterns.isEmpty() || !negativePatterns.isEmpty() )
+        {
+            final List<String> missed = new ArrayList<>();
+            missed.addAll( positivePatterns );
+            missed.addAll( negativePatterns );
+
+            missed.removeAll( patternsTriggered );
+
+            return !missed.isEmpty();
+        }
+
+        return false;
+    }
+
+}

--- a/src/test/java/org/apache/maven/shared/artifact/filter/PatternFilterPerfTest.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/PatternFilterPerfTest.java
@@ -1,21 +1,30 @@
 package org.apache.maven.shared.artifact.filter;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;

--- a/src/test/java/org/apache/maven/shared/artifact/filter/PatternFilterPerfTest.java
+++ b/src/test/java/org/apache/maven/shared/artifact/filter/PatternFilterPerfTest.java
@@ -1,0 +1,122 @@
+package org.apache.maven.shared.artifact.filter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+public class PatternFilterPerfTest {
+
+    @State(Scope.Benchmark)
+    static public class OldPatternState {
+
+        @Param({
+                "groupId:artifact-00,groupId:artifact-01,groupId:artifact-02,groupId:artifact-03,groupId:artifact-04,groupId:artifact-05,groupId:artifact-06,groupId:artifact-07,groupId:artifact-08,groupId:artifact-09",
+                "groupId:artifact-99",
+                "groupId:artifact-*",
+                "*:artifact-99",
+                "*:artifact-*",
+                "*:artifact-*:*",
+                "*:artifact-99:*",
+        })
+        public String patterns;
+
+        ArtifactFilter filter;
+        Artifact artifact;
+
+        @Setup(Level.Invocation)
+        public void setup()
+        {
+            filter = new OldPatternIncludesArtifactFilter( Arrays.asList( patterns.split( "," ) ) );
+            artifact = new DefaultArtifact(
+                    "groupId", "artifact-99", "1.0", "runtime",
+                    "jar", "", null
+            );
+        }
+
+    }
+
+    @State(Scope.Benchmark)
+    static public class NewPatternState {
+
+        @Param({
+                "groupId:artifact-00,groupId:artifact-01,groupId:artifact-02,groupId:artifact-03,groupId:artifact-04,groupId:artifact-05,groupId:artifact-06,groupId:artifact-07,groupId:artifact-08,groupId:artifact-09",
+                "groupId:artifact-99",
+                "groupId:artifact-*",
+                "*:artifact-99",
+                "*:artifact-*",
+                "*:artifact-*:*",
+                "*:artifact-99:*",
+        })
+        public String patterns;
+
+        ArtifactFilter filter;
+        Artifact artifact;
+
+        @Setup(Level.Invocation)
+        public void setup()
+        {
+            filter = new PatternIncludesArtifactFilter( Arrays.asList( patterns.split( "," ) ) );
+            artifact = new DefaultArtifact(
+                    "groupId", "artifact-99", "1.0", "runtime",
+                    "jar", "", null
+            );
+        }
+
+    }
+
+
+    @Benchmark
+    public boolean newPatternTest(NewPatternState state )
+    {
+        return state.filter.include( state.artifact );
+    }
+
+    @Benchmark
+    public boolean oldPatternTest(OldPatternState state )
+    {
+        return state.filter.include( state.artifact );
+    }
+
+    public static void main( String... args )
+            throws RunnerException
+    {
+        Options opts = new OptionsBuilder()
+                .measurementIterations( 3 )
+                .measurementTime( TimeValue.milliseconds( 3000 ) )
+                .forks( 1 )
+                .include( "org.apache.maven.shared.artifact.filter.PatternFilterPerfTest" )
+                .build();
+        new Runner( opts ).run();
+    }
+}


### PR DESCRIPTION
This can be a huge boost for dependency sets that contains lots of artifact ids such as https://github.com/apache/camel/blob/2870bb9e619b4e18bfe8de11b449be9cd67d1f3c/apache-camel/src/main/descriptors/common-bin.xml