### PR TITLE
[MSHARED-1104] Four element pattern may be GATV or GATC

### DIFF
--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -475,12 +475,12 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
         }
     }
 
-    private static Pattern toPattern( final String token, final Coordinate... coordinate )
+    private static Pattern toPattern( final String token, final Coordinate... coordinates )
     {
-        return toPattern( token, token, coordinate );
+        return toPattern( token, token, coordinates );
     }
 
-    private static Pattern toPattern( final String pattern, final String token, final Coordinate... coordinate )
+    private static Pattern toPattern( final String pattern, final String token, final Coordinate... coordinates )
     {
         if ( ANY.equals( token ) )
         {
@@ -488,9 +488,9 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
         }
         else
         {
-            EnumSet<Coordinate> coordinates = EnumSet.noneOf( Coordinate.class );
-            coordinates.addAll( Arrays.asList( coordinate ) );
-            return new CoordinateMatchingPattern( pattern, token, coordinates );
+            EnumSet<Coordinate> coordinateSet = EnumSet.noneOf( Coordinate.class );
+            coordinateSet.addAll( Arrays.asList( coordinates ) );
+            return new CoordinateMatchingPattern( pattern, token, coordinateSet );
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -365,7 +365,7 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
             }
             else if ( tokens.length == 4 )
             {
-                // trivial, full pattern w/o classifier: G:A:T:V or G:A:T:C
+                // trivial, full pattern w/ version or classifier: G:A:T:V or G:A:T:C
                 patterns.add( toPattern( tokens[0], Coordinate.GROUP_ID ) );
                 patterns.add( toPattern( tokens[1], Coordinate.ARTIFACT_ID ) );
                 patterns.add( toPattern( tokens[2], Coordinate.TYPE ) );

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -20,6 +20,7 @@ package org.apache.maven.shared.artifact.filter;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -364,11 +365,11 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
             }
             else if ( tokens.length == 4 )
             {
-                // trivial, full pattern w/o classifier: G:A:T:V
+                // trivial, full pattern w/o classifier: G:A:T:V or G:A:T:C
                 patterns.add( toPattern( tokens[0], Coordinate.GROUP_ID ) );
                 patterns.add( toPattern( tokens[1], Coordinate.ARTIFACT_ID ) );
                 patterns.add( toPattern( tokens[2], Coordinate.TYPE ) );
-                patterns.add( toPattern( tokens[3], Coordinate.BASE_VERSION ) );
+                patterns.add( toPattern( tokens[3], Coordinate.CLASSIFIER, Coordinate.BASE_VERSION ) );
             }
             else if ( tokens.length == 3 )
             {
@@ -481,7 +482,7 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
         }
     }
 
-    private static Pattern toPattern( final String token, final Coordinate coordinate )
+    private static Pattern toPattern( final String token, final Coordinate... coordinate )
     {
         if ( ANY.equals( token ) )
         {
@@ -489,7 +490,9 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
         }
         else
         {
-            return new CoordinateMatchingPattern( token, token, EnumSet.of( coordinate ) );
+            EnumSet<Coordinate> coordinates = EnumSet.noneOf( Coordinate.class );
+            coordinates.addAll( Arrays.asList( coordinate ) );
+            return new CoordinateMatchingPattern( token, token, coordinates );
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
+++ b/src/main/java/org/apache/maven/shared/artifact/filter/PatternIncludesArtifactFilter.java
@@ -369,7 +369,7 @@ public class PatternIncludesArtifactFilter implements ArtifactFilter, Statistics
                 patterns.add( toPattern( tokens[0], Coordinate.GROUP_ID ) );
                 patterns.add( toPattern( tokens[1], Coordinate.ARTIFACT_ID ) );
                 patterns.add( toPattern( tokens[2], Coordinate.TYPE ) );
-                patterns.add( toPattern( tokens[3], Coordinate.CLASSIFIER, Coordinate.BASE_VERSION ) );
+                patterns.add( toPattern( tokens[3], Coordinate.BASE_VERSION, Coordinate.CLASSIFIER ) );
             }
             else if ( tokens.length == 3 )
             {


### PR DESCRIPTION
This simple patch makes 4 element pattern
be interpeted as GATV (as before) or as GATC.

Also, cleanup how patterns are created, make 
everywhere toPattern static helper is used, no need
for direct ctor invocation, and it simplifies things.

---

https://issues.apache.org/jira/browse/MSHARED-1104